### PR TITLE
Fix: set type to 'other' for non-AV assets (fixes #13)

### DIFF
--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -188,6 +188,9 @@ class AbstractAsset {
       type,
       hasThumb: (type === 'image' && subtype !== 'svg+xml') || type === 'video'
     })
+    if (!this.isAudio && !this.isVideo && !this.isImage) {
+      this.data.type = 'other'
+    }
     // perform filesystem operations
     const localAsset = this.assets.createFsWrapper({ repo: 'local', path: file.filepath })
     await this.write(await localAsset.read(), this.path)

--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -185,12 +185,9 @@ class AbstractAsset {
       repo: this.data.repo,
       size: file.size,
       subtype,
-      type,
+      type: (!this.isAudio && !this.isVideo && !this.isImage) ? 'other' : type,
       hasThumb: (type === 'image' && subtype !== 'svg+xml') || type === 'video'
     })
-    if (!this.isAudio && !this.isVideo && !this.isImage) {
-      this.data.type = 'other'
-    }
     // perform filesystem operations
     const localAsset = this.assets.createFsWrapper({ repo: 'local', path: file.filepath })
     await this.write(await localAsset.read(), this.path)


### PR DESCRIPTION
#13 

### Fix
* set type to 'other' for non-AV assets
