### PR TITLE
Update: Add ability to specify custom ffmpeg/ffprobe commands (fixes #36)

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -8,6 +8,14 @@
       "isDirectory": true,
       "default": "$DATA/assets"
     },
+    "customFfmpegCommand": {
+      "description": "Custom command to run the ffmpeg CLI",
+      "type": "string"
+    },
+    "customFfprobeCommand": {
+      "description": "Custom command to run the ffprobe CLI",
+      "type": "string"
+    },
     "defaultAssetRepository": {
       "description": "Default repository to use for asset storage",
       "type": "string",

--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -203,17 +203,19 @@ class AbstractAsset {
     this.assets.log('debug', 'FFPROBE', cmd, args)
     this.assets.log('verbose', 'FFPROBE', 'cwd:', cwd)
 
-    let streamData
+    let streams
+    let format
     try {
-      const { streams, format } = JSON.parse(await Utils.spawn({ cmd, args, cwd }))
-      streamData = streams.find(s => s.codec_type === 'video')
-      this.assets.log('verbose', 'FFPROBE', { ...streamData, format })
-
+      const outputData = JSON.parse(await Utils.spawn({ cmd, args, cwd }))
+      format = outputData.format
+      streams = outputData.streams
     } catch (e) {
       throw App.instance.errors.FFPROBE.setData({ error: e, command: [cmd, ...args].join(' '), cwd })
     } finally {
       await tempAsset.delete()
     }
+    const streamData = streams.find(s => s.codec_type === 'video')
+    this.assets.log('verbose', 'FFPROBE', { ...streamData, format })
     const metadata = {}
     if (streamData.width && streamData.height) metadata.resolution = `${streamData.width}x${streamData.height}`
     if (this.isVideo) metadata.duration = Math.floor(Number(streamData.duration))

--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -1,12 +1,8 @@
 import { App, Utils } from 'adapt-authoring-core'
-import { exec as execCallback } from 'child_process'
 import ffmpeg from '@ffmpeg-installer/ffmpeg'
 import ffprobe from '@ffprobe-installer/ffprobe'
 import mime from 'mime'
 import path from 'path'
-import util from 'util'
-
-const exec = util.promisify(execCallback)
 
 /**
  * Base class for handling an asset

--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -1,4 +1,4 @@
-import { App } from 'adapt-authoring-core'
+import { App, Utils } from 'adapt-authoring-core'
 import { exec as execCallback } from 'child_process'
 import ffmpeg from '@ffmpeg-installer/ffmpeg'
 import ffprobe from '@ffprobe-installer/ffprobe'
@@ -129,11 +129,12 @@ class AbstractAsset {
      * temporarily download the asset locally before processing
      */
     const { default: LocalAsset } = await import('./LocalAsset.js')
-    const tempAsset = new LocalAsset({ path: path.join(this.thumb.dirname, `TEMP_${this.filename}`) })
+    const cwd = this.thumb.dirname
+    const tempAsset = new LocalAsset({ path: path.join(cwd, `TEMP_${this.filename}`) })
     await tempAsset.write(await this.read(), tempAsset.path)
 
-    const ffmpegCmd = [
-      ffmpeg.path,
+    const cmd = this.getConfig('customFfmpegCommand') ?? ffmpeg.path
+    const args = [
       `-i ${tempAsset.filename}`,
       `-vf scale=${this.assets.getConfig('thumbnailWidth')}:-1`,
       '-vframes 1',
@@ -142,16 +143,17 @@ class AbstractAsset {
       '-hide_banner',
       '-loglevel error',
       this.thumb.filename
-    ].join(' ')
+    ]
+    this.assets.log('debug', 'FFMPEG', cmd, args)
+    this.assets.log('verbose', 'FFMPEG', 'cwd:', cwd)
 
-    this.assets.log('debug', 'FFMPEG', ffmpegCmd)
-    this.assets.log('verbose', 'FFMPEG', 'cwd:', this.thumb.dirname)
-
-    const { stderr } = await exec(ffmpegCmd, { cwd: this.thumb.dirname })
-
-    await tempAsset.delete()
-
-    if (stderr) throw App.instance.errors.FFMPEG.setData({ message: stderr, command: ffmpegCmd, cwd: this.thumb.dirname })
+    try {
+      await Utils.spawn({ cmd, args, cwd })
+    } catch (e) {
+      throw App.instance.errors.FFMPEG.setData({ message: e, command: [cmd, ...args].join(' '), cwd })
+    } finally {
+      await tempAsset.delete()
+    }
   }
 
   /**
@@ -189,33 +191,33 @@ class AbstractAsset {
     if (!this.hasThumb) { // if there's no thumb, then it's the wrong type of file for calculating the extra metadata
       return {}
     }
-    const cwd = App.instance.getConfig('tempDir')
     const { default: LocalAsset } = await import('./LocalAsset.js')
+    const cwd = App.instance.getConfig('tempDir')
     const tempAsset = new LocalAsset({ path: path.join(cwd, this.filename) })
     await tempAsset.write(await this.read(), tempAsset.path)
 
-    const ffprobeCmd = [
-      ffprobe.path,
+    const cmd = this.getConfig('customFfprobeCommand') ?? ffprobe.path
+    const args = [
       `-i ${this.filename}`,
       '-loglevel error',
       '-print_format json',
       '-show_format',
       '-show_streams'
-    ].join(' ')
-
-    this.assets.log('debug', 'FFPROBE', ffprobeCmd)
+    ]
+    this.assets.log('debug', 'FFPROBE', cmd, args)
     this.assets.log('verbose', 'FFPROBE', 'cwd:', cwd)
 
-    const { stdout, stderr } = await exec(ffprobeCmd, { cwd })
-    const { streams, format } = JSON.parse(stdout)
-    const streamData = streams.find(s => s.codec_type === 'video')
+    let streamData
+    try {
+      const { streams, format } = JSON.parse(await Utils.spawn({ cmd, args, cwd }))
+      streamData = streams.find(s => s.codec_type === 'video')
+      this.assets.log('verbose', 'FFPROBE', { ...streamData, format })
 
-    this.assets.log('verbose', 'FFPROBE', { ...streamData, format })
-
-    await tempAsset.delete()
-
-    if (stderr) throw App.instance.errors.FFPROBE.setData({ error: stderr, command: ffprobeCmd, cwd })
-
+    } catch (e) {
+      throw App.instance.errors.FFPROBE.setData({ error: e, command: [cmd, ...args].join(' '), cwd })
+    } finally {
+      await tempAsset.delete()
+    }
     const metadata = {}
     if (streamData.width && streamData.height) metadata.resolution = `${streamData.width}x${streamData.height}`
     if (this.isVideo) metadata.duration = Math.floor(Number(streamData.duration))


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#36

[//]: # (Delete as appropriate)
### Update
* Add ability to specify custom commands for ffmpeg/ffprobe (e.g. for using a local installation)