### PR TITLE
Fix: asset config retrieval for ffmpeg and ffprobe commands (fixes #41)

### DIFF
--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -131,15 +131,15 @@ class AbstractAsset {
 
     const cmd = this.assets.getConfig('customFfmpegCommand') ?? ffmpeg.path
     const args = [
-      `-i ${tempAsset.filename}`,
-      `-vf scale=${this.assets.getConfig('thumbnailWidth')}:-1`,
-      '-vframes 1',
-      '-update 1',
-      this.isVideo ? '-ss 00:00:05.000' : '',
+      '-i', tempAsset.filename,
+      '-vf', `scale=${this.assets.getConfig('thumbnailWidth')}:-1`,
+      '-vframes', '1',
+      '-update', '1',
+      ...(this.isVideo ? ['-ss', '00:00:05.000'] : ['']),
       '-hide_banner',
-      '-loglevel error',
+      '-loglevel', 'error',
       this.thumb.filename
-    ]
+    ].filter(Boolean)
     this.assets.log('debug', 'FFMPEG', cmd, args)
     this.assets.log('verbose', 'FFMPEG', 'cwd:', cwd)
 
@@ -194,9 +194,9 @@ class AbstractAsset {
 
     const cmd = this.assets.getConfig('customFfprobeCommand') ?? ffprobe.path
     const args = [
-      `-i ${this.filename}`,
-      '-loglevel error',
-      '-print_format json',
+      '-i', this.filename,
+      '-loglevel', 'error',
+      '-print_format', 'json',
       '-show_format',
       '-show_streams'
     ]

--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -129,7 +129,7 @@ class AbstractAsset {
     const tempAsset = new LocalAsset({ path: path.join(cwd, `TEMP_${this.filename}`) })
     await tempAsset.write(await this.read(), tempAsset.path)
 
-    const cmd = this.getConfig('customFfmpegCommand') ?? ffmpeg.path
+    const cmd = this.assets.getConfig('customFfmpegCommand') ?? ffmpeg.path
     const args = [
       `-i ${tempAsset.filename}`,
       `-vf scale=${this.assets.getConfig('thumbnailWidth')}:-1`,
@@ -192,7 +192,7 @@ class AbstractAsset {
     const tempAsset = new LocalAsset({ path: path.join(cwd, this.filename) })
     await tempAsset.write(await this.read(), tempAsset.path)
 
-    const cmd = this.getConfig('customFfprobeCommand') ?? ffprobe.path
+    const cmd = this.assets.getConfig('customFfprobeCommand') ?? ffprobe.path
     const args = [
       `-i ${this.filename}`,
       '-loglevel error',


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#41 

[//]: # (Delete as appropriate)
### Fix
* Fix issue with config retrieval for ffmpeg/ffprobe


