### PR TITLE
Upgrade: adapt-authoring-api to ^3.0.0 and migrate to routes.json

### DIFF
--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -31,24 +31,9 @@ class Assetsmodule extends AbstractApiModule {
 
   /** @override */
   async setValues () {
-    this.root = 'assets'
+    await super.setValues()
     this.collectionName = 'assets'
     this.schemaName = 'asset'
-
-    this.useDefaultRouteConfig()
-
-    this.routes.push({
-      route: '/serve/:_id',
-      handlers: { get: [this.serveAssetHandler.bind(this)] },
-      permissions: { get: [`read:${this.root}`] },
-      meta: {
-        get: {
-          summary: 'Retrieve an asset file',
-          parameters: [{ name: 'thumb', in: 'query', description: 'Whether the thumbnail should be sent', schema: { type: 'string', enum: ['true', 'false'], default: 'false' } }],
-          responses: { 200: { description: 'The asset file' } }
-        }
-      }
-    })
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
-    "adapt-authoring-api": "^2.0.0",
+    "adapt-authoring-api": "^3.0.0",
     "adapt-authoring-core": "^2.0.0",
     "mime": "^4.1.0"
   },

--- a/routes.json
+++ b/routes.json
@@ -1,0 +1,17 @@
+{
+  "root": "assets",
+  "routes": [
+    {
+      "route": "/serve/:_id",
+      "handlers": { "get": "serveAssetHandler" },
+      "permissions": { "get": ["read:${scope}"] },
+      "meta": {
+        "get": {
+          "summary": "Retrieve an asset file",
+          "parameters": [{ "name": "thumb", "in": "query", "description": "Whether the thumbnail should be sent", "schema": { "type": "string", "enum": ["true", "false"], "default": "false" } }],
+          "responses": { "200": { "description": "The asset file" } }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Upgrade
* Bump adapt-authoring-api dependency from ^2.0.0 to ^3.0.0

### Update
* Move route definitions from imperative code to routes.json
* Replace useDefaultRouteConfig() with super.setValues() for routes.json loading
* Preserve API meta for serve endpoint

### Testing
1. Run `npm test` — all 21 tests pass
2. Verify asset upload, retrieval, and serve operations work via the API