### PR TITLE
New: Add duplicate asset detection via content hashing

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -1,4 +1,12 @@
 {
+  "DUPLICATE_ASSET": {
+    "data": {
+      "hash": "The file hash",
+      "assetId": "The ID of the existing asset"
+    },
+    "description": "An asset with identical file content already exists",
+    "statusCode": 409
+  },
   "ASSET_NO_PATH": {
     "data": {
       "title": "Asset title"

--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -1,6 +1,7 @@
 import { App, spawn } from 'adapt-authoring-core'
 import ffmpeg from '@ffmpeg-installer/ffmpeg'
 import ffprobe from '@ffprobe-installer/ffprobe'
+import generateHash from './utils/generateHash.js'
 import mime from 'mime'
 import path from 'path'
 
@@ -159,9 +160,12 @@ class AbstractAsset {
    */
   async updateFile (file) {
     const [type, subtype] = mime.getType(file.originalFilename).split('/')
+    // compute hash while file is still in temp location (no extra I/O)
+    const hash = await generateHash(file.filepath)
     // remove old file and set new path
     await this.delete()
     this.setData({
+      hash,
       path: `${this.data._id}.${this.getFileExtension(file)}`,
       repo: this.data.repo,
       size: file.size,

--- a/lib/AbstractAsset.js
+++ b/lib/AbstractAsset.js
@@ -158,10 +158,10 @@ class AbstractAsset {
    * @param {FormidableFile} file Uploaded file data
    * @returns {object} The update data
    */
-  async updateFile (file) {
+  async updateFile (file, precomputedHash) {
     const [type, subtype] = mime.getType(file.originalFilename).split('/')
-    // compute hash while file is still in temp location (no extra I/O)
-    const hash = await generateHash(file.filepath)
+    // use precomputed hash if provided, otherwise compute it now
+    const hash = precomputedHash ?? await generateHash(file.filepath)
     // remove old file and set new path
     await this.delete()
     this.setData({

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -3,6 +3,7 @@ import AbstractAsset from './AbstractAsset.js'
 import ffmpeg from '@ffmpeg-installer/ffmpeg'
 import ffprobe from '@ffprobe-installer/ffprobe'
 import fs from 'fs/promises'
+import generateHash from './utils/generateHash.js'
 import LocalAsset from 'adapt-authoring-assets/lib/LocalAsset.js'
 /**
  * Handling of assets
@@ -19,7 +20,8 @@ class Assetsmodule extends AbstractApiModule {
     this.assetTypes = { [LocalAsset.name]: LocalAsset }
 
     await this.ensureLibPermissions()
-    const [authored, tags] = await this.app.waitForModule('authored', 'tags')
+    const [authored, mongodb, tags] = await this.app.waitForModule('authored', 'mongodb', 'tags')
+    await mongodb.setIndex(this.collectionName, 'hash')
     await authored.registerModule(this, { accessCheck: false })
     await tags.registerModule(this)
 
@@ -156,8 +158,27 @@ class Assetsmodule extends AbstractApiModule {
     return super.find(query, options, mongoOptions)
   }
 
+  /**
+   * Checks for an existing asset with the same file hash
+   * @param {string} filepath Path to the uploaded file
+   * @param {object} [excludeQuery] Optional query to exclude (e.g. self on update)
+   * @throws {DUPLICATE_ASSET} If a duplicate is found
+   * @returns {Promise<string>} The computed hash
+   */
+  async checkDuplicate (filepath, excludeQuery) {
+    const hash = await generateHash(filepath)
+    const query = { hash }
+    if (excludeQuery) Object.assign(query, excludeQuery)
+    const existing = await this.find(query)
+    if (existing.length) {
+      throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing[0]._id.toString() })
+    }
+    return hash
+  }
+
   /** @override */
   async insert (data, options, mongoOptions) {
+    await this.checkDuplicate(data.file.filepath)
     const doc = await super.insert(data, options, mongoOptions)
     try {
       const updateData = await this.createFsWrapper(doc).updateFile(data.file, { deleteOnError: true })
@@ -172,6 +193,7 @@ class Assetsmodule extends AbstractApiModule {
   async update (query, data, options, mongoOptions) {
     const doc = await super.update({ _id: query._id }, data, options, mongoOptions)
     if (!data.file) return doc
+    await this.checkDuplicate(data.file.filepath, { _id: { $ne: query._id } })
     const updateData = await this.createFsWrapper(doc).updateFile(data.file)
     return super.update({ _id: query._id }, updateData, options, mongoOptions)
   }

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -171,6 +171,7 @@ class Assetsmodule extends AbstractApiModule {
     if (excludeQuery) Object.assign(query, excludeQuery)
     const existing = await this.find(query)
     if (existing.length) {
+      this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${existing[0]._id} (hash: ${hash})`)
       throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing[0]._id.toString() })
     }
     return hash

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -174,13 +174,13 @@ class Assetsmodule extends AbstractApiModule {
     // size pre-check: skip expensive hashing when no asset shares this file size
     const sizeQuery = { size: fileSize }
     if (excludeQuery) Object.assign(sizeQuery, excludeQuery)
-    const sizeMatch = await this.findOne(sizeQuery)
+    const sizeMatch = await this.findOne(sizeQuery, { throwOnMissing: false })
     if (!sizeMatch) return null
     // a candidate exists — compute hash and confirm exact duplicate
     const hash = await generateHash(filepath)
     const hashQuery = { hash }
     if (excludeQuery) Object.assign(hashQuery, excludeQuery)
-    const existing = await this.findOne(hashQuery)
+    const existing = await this.findOne(hashQuery, { throwOnMissing: false })
     if (existing) {
       this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${existing._id} (hash: ${hash})`)
       throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing._id.toString() })

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -1,5 +1,6 @@
 import AbstractApiModule from 'adapt-authoring-api'
 import AbstractAsset from './AbstractAsset.js'
+import checkDuplicate from './utils/checkDuplicate.js'
 import ffmpeg from '@ffmpeg-installer/ffmpeg'
 import ffprobe from '@ffprobe-installer/ffprobe'
 import fs from 'fs/promises'
@@ -173,22 +174,14 @@ class Assetsmodule extends AbstractApiModule {
    * @returns {Promise<string|null>} The computed hash if a size candidate was found, or null if not
    */
   async checkDuplicate (filepath, fileSize, excludeQuery) {
-    // size pre-check: skip expensive hashing when no asset shares this file size.
-    // use find() rather than findOne() — multiple assets may legitimately share a byte length.
-    const sizeQuery = { size: fileSize }
-    if (excludeQuery) Object.assign(sizeQuery, excludeQuery)
-    const [sizeMatch] = await this.find(sizeQuery)
-    if (!sizeMatch) return null
-    // a candidate exists — compute hash and confirm exact duplicate
-    const hash = await generateHash(filepath)
-    const hashQuery = { hash }
-    if (excludeQuery) Object.assign(hashQuery, excludeQuery)
-    const [existing] = await this.find(hashQuery)
-    if (existing) {
-      this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${existing._id} (hash: ${hash})`)
-      throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing._id.toString() })
-    }
-    return hash
+    return checkDuplicate(filepath, fileSize, excludeQuery, {
+      findFn: q => this.find(q),
+      generateHash,
+      makeDuplicateError: data => {
+        this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${data.assetId} (hash: ${data.hash})`)
+        return this.app.errors.DUPLICATE_ASSET.setData(data)
+      }
+    })
   }
 
   /** @override */

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -169,10 +169,10 @@ class Assetsmodule extends AbstractApiModule {
     const hash = await generateHash(filepath)
     const query = { hash }
     if (excludeQuery) Object.assign(query, excludeQuery)
-    const existing = await this.find(query)
-    if (existing.length) {
-      this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${existing[0]._id} (hash: ${hash})`)
-      throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing[0]._id.toString() })
+    const existing = await this.findOne(query)
+    if (existing) {
+      this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${existing._id} (hash: ${hash})`)
+      throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing._id.toString() })
     }
     return hash
   }

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -161,11 +161,14 @@ class Assetsmodule extends AbstractApiModule {
   /**
    * Checks for an existing asset with the same file content.
    * Uses a cheap size pre-check to avoid hashing when no candidate exists.
+   * When no size match is found, returns null so the caller can defer hash
+   * computation to {@link AbstractAsset#updateFile}, which handles null via
+   * its precomputedHash parameter fallback.
    * @param {string} filepath Path to the uploaded file
    * @param {number} fileSize Size of the uploaded file in bytes
    * @param {object} [excludeQuery] Optional query to exclude (e.g. self on update)
    * @throws {DUPLICATE_ASSET} If a duplicate is found
-   * @returns {Promise<string|null>} The computed hash, or null if no size match (hash not needed yet)
+   * @returns {Promise<string|null>} The computed hash if a size candidate was found, or null if not
    */
   async checkDuplicate (filepath, fileSize, excludeQuery) {
     // size pre-check: skip expensive hashing when no asset shares this file size

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -142,7 +142,9 @@ class Assetsmodule extends AbstractApiModule {
     try {
       const assetData = await this.findOne({ _id: req.apiData.query._id })
       const asset = this.createFsWrapper(assetData)
-      const fileStream = await (req.query.thumb === 'true' ? asset.thumb.read() : asset.read())
+      // fall back to the main asset when a thumb is requested but none exists (e.g. SVG)
+      const wantsThumb = req.query.thumb === 'true' && asset.hasThumb
+      const fileStream = await (wantsThumb ? asset.thumb.read() : asset.read())
       res.set('Content-Type', `${asset.data.type}/${asset.data.subtype}`)
       fileStream.pipe(res)
     } catch (e) {
@@ -171,16 +173,17 @@ class Assetsmodule extends AbstractApiModule {
    * @returns {Promise<string|null>} The computed hash if a size candidate was found, or null if not
    */
   async checkDuplicate (filepath, fileSize, excludeQuery) {
-    // size pre-check: skip expensive hashing when no asset shares this file size
+    // size pre-check: skip expensive hashing when no asset shares this file size.
+    // use find() rather than findOne() — multiple assets may legitimately share a byte length.
     const sizeQuery = { size: fileSize }
     if (excludeQuery) Object.assign(sizeQuery, excludeQuery)
-    const sizeMatch = await this.findOne(sizeQuery, { throwOnMissing: false })
+    const [sizeMatch] = await this.find(sizeQuery)
     if (!sizeMatch) return null
     // a candidate exists — compute hash and confirm exact duplicate
     const hash = await generateHash(filepath)
     const hashQuery = { hash }
     if (excludeQuery) Object.assign(hashQuery, excludeQuery)
-    const existing = await this.findOne(hashQuery, { throwOnMissing: false })
+    const [existing] = await this.find(hashQuery)
     if (existing) {
       this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${existing._id} (hash: ${hash})`)
       throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing._id.toString() })

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -159,17 +159,25 @@ class Assetsmodule extends AbstractApiModule {
   }
 
   /**
-   * Checks for an existing asset with the same file hash
+   * Checks for an existing asset with the same file content.
+   * Uses a cheap size pre-check to avoid hashing when no candidate exists.
    * @param {string} filepath Path to the uploaded file
+   * @param {number} fileSize Size of the uploaded file in bytes
    * @param {object} [excludeQuery] Optional query to exclude (e.g. self on update)
    * @throws {DUPLICATE_ASSET} If a duplicate is found
-   * @returns {Promise<string>} The computed hash
+   * @returns {Promise<string|null>} The computed hash, or null if no size match (hash not needed yet)
    */
-  async checkDuplicate (filepath, excludeQuery) {
+  async checkDuplicate (filepath, fileSize, excludeQuery) {
+    // size pre-check: skip expensive hashing when no asset shares this file size
+    const sizeQuery = { size: fileSize }
+    if (excludeQuery) Object.assign(sizeQuery, excludeQuery)
+    const sizeMatch = await this.findOne(sizeQuery)
+    if (!sizeMatch) return null
+    // a candidate exists — compute hash and confirm exact duplicate
     const hash = await generateHash(filepath)
-    const query = { hash }
-    if (excludeQuery) Object.assign(query, excludeQuery)
-    const existing = await this.findOne(query)
+    const hashQuery = { hash }
+    if (excludeQuery) Object.assign(hashQuery, excludeQuery)
+    const existing = await this.findOne(hashQuery)
     if (existing) {
       this.log('debug', 'DUPLICATE_ASSET', `skipped asset creation, file matches existing asset ${existing._id} (hash: ${hash})`)
       throw this.app.errors.DUPLICATE_ASSET.setData({ hash, assetId: existing._id.toString() })
@@ -179,7 +187,7 @@ class Assetsmodule extends AbstractApiModule {
 
   /** @override */
   async insert (data, options, mongoOptions) {
-    const hash = await this.checkDuplicate(data.file.filepath)
+    const hash = await this.checkDuplicate(data.file.filepath, data.file.size)
     const doc = await super.insert(data, options, mongoOptions)
     try {
       const updateData = await this.createFsWrapper(doc).updateFile(data.file, hash)
@@ -194,7 +202,7 @@ class Assetsmodule extends AbstractApiModule {
   async update (query, data, options, mongoOptions) {
     const doc = await super.update({ _id: query._id }, data, options, mongoOptions)
     if (!data.file) return doc
-    const hash = await this.checkDuplicate(data.file.filepath, { _id: { $ne: query._id } })
+    const hash = await this.checkDuplicate(data.file.filepath, data.file.size, { _id: { $ne: query._id } })
     const updateData = await this.createFsWrapper(doc).updateFile(data.file, hash)
     return super.update({ _id: query._id }, updateData, options, mongoOptions)
   }

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -179,10 +179,10 @@ class Assetsmodule extends AbstractApiModule {
 
   /** @override */
   async insert (data, options, mongoOptions) {
-    await this.checkDuplicate(data.file.filepath)
+    const hash = await this.checkDuplicate(data.file.filepath)
     const doc = await super.insert(data, options, mongoOptions)
     try {
-      const updateData = await this.createFsWrapper(doc).updateFile(data.file, { deleteOnError: true })
+      const updateData = await this.createFsWrapper(doc).updateFile(data.file, hash)
       return await super.update({ _id: doc._id }, updateData, options, mongoOptions)
     } catch (e) {
       await this.delete({ _id: doc._id }, options, mongoOptions)
@@ -194,8 +194,8 @@ class Assetsmodule extends AbstractApiModule {
   async update (query, data, options, mongoOptions) {
     const doc = await super.update({ _id: query._id }, data, options, mongoOptions)
     if (!data.file) return doc
-    await this.checkDuplicate(data.file.filepath, { _id: { $ne: query._id } })
-    const updateData = await this.createFsWrapper(doc).updateFile(data.file)
+    const hash = await this.checkDuplicate(data.file.filepath, { _id: { $ne: query._id } })
+    const updateData = await this.createFsWrapper(doc).updateFile(data.file, hash)
     return super.update({ _id: query._id }, updateData, options, mongoOptions)
   }
 

--- a/lib/migrate-hashes.js
+++ b/lib/migrate-hashes.js
@@ -1,0 +1,59 @@
+/**
+ * Migration script to compute SHA-256 hashes for existing asset records.
+ *
+ * Run manually from the adapt-authoring root:
+ *   node assets/lib/migrate-hashes.js
+ *
+ * Requires a running MongoDB instance with the app's configuration.
+ */
+import { App } from 'adapt-authoring-core'
+import generateHash from './utils/generateHash.js'
+
+async function migrate () {
+  const app = App.instance
+  await app.onReady()
+
+  const assets = await app.waitForModule('assets')
+  const docs = await assets.find({ $or: [{ hash: null }, { hash: { $exists: false } }] })
+
+  console.log(`Found ${docs.length} assets without a hash`)
+
+  const duplicates = new Map()
+  let updated = 0
+  let errors = 0
+
+  for (const doc of docs) {
+    try {
+      const asset = assets.createFsWrapper(doc)
+      await asset.ensureExists()
+      const hash = await generateHash(asset.path)
+      await assets.update({ _id: doc._id }, { hash }, { schemaOptions: { ignoreReadOnly: true } })
+
+      if (duplicates.has(hash)) {
+        duplicates.get(hash).push(doc._id)
+      } else {
+        duplicates.set(hash, [doc._id])
+      }
+      updated++
+    } catch (e) {
+      console.error(`Failed to hash asset ${doc._id}: ${e.message}`)
+      errors++
+    }
+  }
+
+  const dupeEntries = [...duplicates.entries()].filter(([, ids]) => ids.length > 1)
+  if (dupeEntries.length) {
+    console.log(`\nDuplicate hashes found (${dupeEntries.length}):`)
+    for (const [hash, ids] of dupeEntries) {
+      console.log(`  ${hash}: ${ids.join(', ')}`)
+    }
+  }
+
+  console.log(`\nDone. Updated: ${updated}, Errors: ${errors}`)
+  process.exit(0)
+}
+
+migrate().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/lib/migrate-hashes.js
+++ b/lib/migrate-hashes.js
@@ -1,5 +1,7 @@
 /**
- * Migration script to compute SHA-256 hashes for existing asset records.
+ * Migration script to compute SHA-256 hashes for existing asset records
+ * and merge any duplicates by updating all references to point to the
+ * oldest asset in each duplicate group.
  *
  * Run manually from the adapt-authoring root:
  *   node assets/lib/migrate-hashes.js
@@ -8,6 +10,10 @@
  */
 import { App } from 'adapt-authoring-core'
 import generateHash from './utils/generateHash.js'
+
+const assetPredicate = field => {
+  return field?._backboneForms?.type === 'Asset' || field?._backboneForms === 'Asset'
+}
 
 async function migrate () {
   const app = App.instance
@@ -18,7 +24,7 @@ async function migrate () {
 
   console.log(`Found ${docs.length} assets without a hash`)
 
-  const duplicates = new Map()
+  const hashGroups = new Map()
   let updated = 0
   let errors = 0
 
@@ -29,10 +35,10 @@ async function migrate () {
       const hash = await generateHash(asset.path)
       await assets.update({ _id: doc._id }, { hash }, { schemaOptions: { ignoreReadOnly: true } })
 
-      if (duplicates.has(hash)) {
-        duplicates.get(hash).push(doc._id)
+      if (hashGroups.has(hash)) {
+        hashGroups.get(hash).push(doc)
       } else {
-        duplicates.set(hash, [doc._id])
+        hashGroups.set(hash, [doc])
       }
       updated++
     } catch (e) {
@@ -41,16 +47,100 @@ async function migrate () {
     }
   }
 
-  const dupeEntries = [...duplicates.entries()].filter(([, ids]) => ids.length > 1)
-  if (dupeEntries.length) {
-    console.log(`\nDuplicate hashes found (${dupeEntries.length}):`)
-    for (const [hash, ids] of dupeEntries) {
-      console.log(`  ${hash}: ${ids.join(', ')}`)
+  console.log(`\nHashing complete. Updated: ${updated}, Errors: ${errors}`)
+
+  const dupeGroups = [...hashGroups.entries()]
+    .filter(([, group]) => group.length > 1)
+    .map(([hash, group]) => {
+      group.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+      return { hash, keeper: group[0], victims: group.slice(1) }
+    })
+
+  if (!dupeGroups.length) {
+    console.log('No duplicate assets to merge')
+    process.exit(0)
+  }
+
+  console.log(`\nFound ${dupeGroups.length} duplicate groups to merge`)
+
+  const victimMap = new Map()
+  for (const { keeper, victims } of dupeGroups) {
+    for (const victim of victims) {
+      victimMap.set(victim._id.toString(), keeper._id.toString())
     }
   }
 
-  console.log(`\nDone. Updated: ${updated}, Errors: ${errors}`)
+  await updateAssetReferences(app, victimMap)
+  await deleteVictimAssets(assets, victimMap)
+
+  console.log('\nDuplicate merge complete')
   process.exit(0)
+}
+
+async function updateAssetReferences (app, victimMap) {
+  const jsonschema = await app.waitForModule('jsonschema')
+  const mongodb = await app.waitForModule('mongodb')
+
+  let totalUpdated = 0
+
+  for (const moduleInstance of Object.values(app.dependencyloader.instances)) {
+    const { collectionName } = moduleInstance
+    if (!collectionName) continue
+
+    const allDocs = await mongodb.find(collectionName, {})
+
+    for (const doc of allDocs) {
+      let schemaName
+      try {
+        schemaName = typeof moduleInstance.getSchemaName === 'function'
+          ? await moduleInstance.getSchemaName(doc)
+          : moduleInstance.schemaName
+      } catch {
+        schemaName = moduleInstance.schemaName
+      }
+      if (!schemaName) continue
+
+      let schema
+      try {
+        schema = await jsonschema.getSchema(schemaName)
+      } catch {
+        continue
+      }
+
+      const matches = schema.walk(doc, assetPredicate)
+      const updates = {}
+
+      for (const match of matches) {
+        const value = match.value?.toString()
+        if (victimMap.has(value)) {
+          const mongoPath = match.path.replace(/\//g, '.')
+          updates[mongoPath] = victimMap.get(value)
+        }
+      }
+
+      if (Object.keys(updates).length) {
+        await mongodb.update(collectionName, { _id: doc._id }, { $set: updates })
+        console.log(`  Updated ${collectionName} ${doc._id}: ${Object.keys(updates).join(', ')}`)
+        totalUpdated++
+      }
+    }
+  }
+
+  console.log(`Updated ${totalUpdated} documents`)
+}
+
+async function deleteVictimAssets (assets, victimMap) {
+  let deleted = 0
+  for (const victimId of victimMap.keys()) {
+    try {
+      await assets.delete({ _id: victimId })
+      console.log(`  Deleted duplicate asset ${victimId}`)
+      deleted++
+    } catch (e) {
+      console.error(`  Failed to delete asset ${victimId}: ${e.message}`)
+    }
+  }
+  console.log(`Deleted ${deleted} duplicate assets`)
 }
 
 migrate().catch(e => {

--- a/lib/migrate-hashes.js
+++ b/lib/migrate-hashes.js
@@ -81,48 +81,60 @@ async function updateAssetReferences (app, victimMap) {
   const jsonschema = await app.waitForModule('jsonschema')
   const mongodb = await app.waitForModule('mongodb')
 
+  const batchSize = 1000
+  const schemaCache = new Map()
   let totalUpdated = 0
 
   for (const moduleInstance of Object.values(app.dependencyloader.instances)) {
     const { collectionName } = moduleInstance
     if (!collectionName) continue
 
-    const allDocs = await mongodb.find(collectionName, {})
+    let skip = 0
 
-    for (const doc of allDocs) {
-      let schemaName
-      try {
-        schemaName = typeof moduleInstance.getSchemaName === 'function'
-          ? await moduleInstance.getSchemaName(doc)
-          : moduleInstance.schemaName
-      } catch {
-        schemaName = moduleInstance.schemaName
-      }
-      if (!schemaName) continue
+    while (true) {
+      const docs = await mongodb.find(collectionName, {}, { skip, limit: batchSize })
+      if (!docs || !docs.length) break
 
-      let schema
-      try {
-        schema = await jsonschema.getSchema(schemaName)
-      } catch {
-        continue
-      }
+      for (const doc of docs) {
+        let schemaName
+        try {
+          schemaName = typeof moduleInstance.getSchemaName === 'function'
+            ? await moduleInstance.getSchemaName(doc)
+            : moduleInstance.schemaName
+        } catch {
+          schemaName = moduleInstance.schemaName
+        }
+        if (!schemaName) continue
 
-      const matches = schema.walk(doc, assetPredicate)
-      const updates = {}
+        let schema = schemaCache.get(schemaName)
+        if (!schema) {
+          try {
+            schema = await jsonschema.getSchema(schemaName)
+            schemaCache.set(schemaName, schema)
+          } catch {
+            continue
+          }
+        }
 
-      for (const match of matches) {
-        const value = match.value?.toString()
-        if (victimMap.has(value)) {
-          const mongoPath = match.path.replace(/\//g, '.')
-          updates[mongoPath] = victimMap.get(value)
+        const matches = schema.walk(doc, assetPredicate)
+        const updates = {}
+
+        for (const match of matches) {
+          const value = match.value?.toString()
+          if (victimMap.has(value)) {
+            const mongoPath = match.path.replace(/\//g, '.')
+            updates[mongoPath] = victimMap.get(value)
+          }
+        }
+
+        if (Object.keys(updates).length) {
+          await mongodb.update(collectionName, { _id: doc._id }, { $set: updates })
+          console.log(`  Updated ${collectionName} ${doc._id}: ${Object.keys(updates).join(', ')}`)
+          totalUpdated++
         }
       }
 
-      if (Object.keys(updates).length) {
-        await mongodb.update(collectionName, { _id: doc._id }, { $set: updates })
-        console.log(`  Updated ${collectionName} ${doc._id}: ${Object.keys(updates).join(', ')}`)
-        totalUpdated++
-      }
+      skip += docs.length
     }
   }
 

--- a/lib/migrate-hashes.js
+++ b/lib/migrate-hashes.js
@@ -4,12 +4,15 @@
  * oldest asset in each duplicate group.
  *
  * Run manually from the adapt-authoring root:
- *   node assets/lib/migrate-hashes.js
+ *   node assets/lib/migrate-hashes.js [--dry-run]
  *
+ * Pass --dry-run to report what would change without writing to the DB.
  * Requires a running MongoDB instance with the app's configuration.
  */
 import { App } from 'adapt-authoring-core'
 import generateHash from './utils/generateHash.js'
+
+const dryRun = process.argv.includes('--dry-run')
 
 const assetPredicate = field => {
   return field?._backboneForms?.type === 'Asset' || field?._backboneForms === 'Asset'
@@ -18,6 +21,8 @@ const assetPredicate = field => {
 async function migrate () {
   const app = App.instance
   await app.onReady()
+
+  if (dryRun) console.log('DRY RUN — no changes will be written\n')
 
   const assets = await app.waitForModule('assets')
   const docs = await assets.find({ $or: [{ hash: null }, { hash: { $exists: false } }] })
@@ -33,7 +38,9 @@ async function migrate () {
       const asset = assets.createFsWrapper(doc)
       await asset.ensureExists()
       const hash = await generateHash(asset.path)
-      await assets.update({ _id: doc._id }, { hash }, { schemaOptions: { ignoreReadOnly: true } })
+      if (!dryRun) {
+        await assets.update({ _id: doc._id }, { hash }, { schemaOptions: { ignoreReadOnly: true } })
+      }
 
       if (hashGroups.has(hash)) {
         hashGroups.get(hash).push(doc)
@@ -128,8 +135,10 @@ async function updateAssetReferences (app, victimMap) {
         }
 
         if (Object.keys(updates).length) {
-          await mongodb.update(collectionName, { _id: doc._id }, { $set: updates })
-          console.log(`  Updated ${collectionName} ${doc._id}: ${Object.keys(updates).join(', ')}`)
+          if (!dryRun) {
+            await mongodb.update(collectionName, { _id: doc._id }, { $set: updates })
+          }
+          console.log(`  ${dryRun ? 'Would update' : 'Updated'} ${collectionName} ${doc._id}: ${Object.keys(updates).join(', ')}`)
           totalUpdated++
         }
       }
@@ -145,14 +154,14 @@ async function deleteVictimAssets (assets, victimMap) {
   let deleted = 0
   for (const victimId of victimMap.keys()) {
     try {
-      await assets.delete({ _id: victimId })
-      console.log(`  Deleted duplicate asset ${victimId}`)
+      if (!dryRun) await assets.delete({ _id: victimId })
+      console.log(`  ${dryRun ? 'Would delete' : 'Deleted'} duplicate asset ${victimId}`)
       deleted++
     } catch (e) {
       console.error(`  Failed to delete asset ${victimId}: ${e.message}`)
     }
   }
-  console.log(`Deleted ${deleted} duplicate assets`)
+  console.log(`${dryRun ? 'Would delete' : 'Deleted'} ${deleted} duplicate assets`)
 }
 
 migrate().catch(e => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,1 @@
+export { default as generateHash } from './utils/generateHash.js'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,1 +1,2 @@
+export { default as checkDuplicate } from './utils/checkDuplicate.js'
 export { default as generateHash } from './utils/generateHash.js'

--- a/lib/utils/checkDuplicate.js
+++ b/lib/utils/checkDuplicate.js
@@ -1,0 +1,33 @@
+/**
+ * Check whether a file matches an existing asset by content hash.
+ *
+ * Pure helper extracted from AssetsModule#checkDuplicate so it can be unit-tested
+ * without booting the app. Pulls in collaborators (find, hash, error factory) via
+ * the deps argument.
+ *
+ * @param {String} filepath Path to the file to check
+ * @param {Number} fileSize Size of the file in bytes
+ * @param {Object} [excludeQuery] Optional Mongo query fragment to exclude (e.g. self on update)
+ * @param {Object} deps
+ * @param {Function} deps.findFn Async (query) => Array<Asset>
+ * @param {Function} deps.generateHash Async (filepath) => String hash
+ * @param {Function} deps.makeDuplicateError Async ({ hash, assetId }) => Error to throw when a match is found
+ * @returns {Promise<String|null>} Hash if a size candidate existed, null otherwise
+ * @throws Result of makeDuplicateError when a hash match is found
+ */
+export default async function checkDuplicate (filepath, fileSize, excludeQuery, { findFn, generateHash, makeDuplicateError }) {
+  // existence checks use find()+[0] not findOne() — assets can share a byte length
+  const sizeQuery = { size: fileSize }
+  if (excludeQuery) Object.assign(sizeQuery, excludeQuery)
+  const [sizeMatch] = await findFn(sizeQuery)
+  if (!sizeMatch) return null
+
+  const hash = await generateHash(filepath)
+  const hashQuery = { hash }
+  if (excludeQuery) Object.assign(hashQuery, excludeQuery)
+  const [existing] = await findFn(hashQuery)
+  if (existing) {
+    throw makeDuplicateError({ hash, assetId: existing._id.toString() })
+  }
+  return hash
+}

--- a/lib/utils/generateHash.js
+++ b/lib/utils/generateHash.js
@@ -1,0 +1,17 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+
+/**
+ * Computes a SHA-256 hex digest for a file
+ * @param {string} filepath Path to the file
+ * @returns {Promise<string>} The hex digest
+ */
+export default function generateHash (filepath) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256')
+    const stream = fs.createReadStream(filepath)
+    stream.on('data', chunk => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+}

--- a/schema/asset.schema.json
+++ b/schema/asset.schema.json
@@ -10,6 +10,15 @@
       "type": "string",
       "isSearchable": true
     },
+    "hash": {
+      "description": "SHA-256 hash of the asset file contents for duplicate detection",
+      "type": "string",
+      "isReadOnly": true,
+      "isInternal": true,
+      "_backboneForms": {
+        "showInUi": false
+      }
+    },
     "duration": {
       "description": "The asset file's duration",
       "type": "number",

--- a/tests/utils-checkDuplicate.spec.js
+++ b/tests/utils-checkDuplicate.spec.js
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import checkDuplicate from '../lib/utils/checkDuplicate.js'
+
+const makeDeps = ({ findResults = [], hashValue = 'h1' } = {}) => {
+  const calls = { find: [], generateHash: 0, makeDuplicateError: 0 }
+  let i = 0
+  return {
+    calls,
+    deps: {
+      findFn: async q => {
+        calls.find.push(q)
+        return findResults[i++] ?? []
+      },
+      generateHash: async () => {
+        calls.generateHash++
+        return hashValue
+      },
+      makeDuplicateError: data => {
+        calls.makeDuplicateError++
+        const err = new Error('DUPLICATE_ASSET')
+        err.code = 'DUPLICATE_ASSET'
+        err.data = data
+        return err
+      }
+    }
+  }
+}
+
+describe('checkDuplicate', () => {
+  it('returns null and skips hashing when no asset shares the file size', async () => {
+    const { deps, calls } = makeDeps({ findResults: [[]] })
+    const result = await checkDuplicate('/tmp/a', 100, undefined, deps)
+    assert.equal(result, null)
+    assert.equal(calls.generateHash, 0)
+    assert.equal(calls.find.length, 1)
+    assert.deepEqual(calls.find[0], { size: 100 })
+  })
+
+  it('returns hash when a size match exists but no hash match', async () => {
+    const sizeMatch = { _id: 'aaaaaaaaaaaaaaaaaaaaaaaa' }
+    const { deps, calls } = makeDeps({ findResults: [[sizeMatch], []], hashValue: 'h1' })
+    const result = await checkDuplicate('/tmp/a', 100, undefined, deps)
+    assert.equal(result, 'h1')
+    assert.equal(calls.generateHash, 1)
+    assert.equal(calls.find.length, 2)
+    assert.deepEqual(calls.find[1], { hash: 'h1' })
+  })
+
+  it('throws DUPLICATE_ASSET when both size and hash match', async () => {
+    const match = { _id: { toString: () => 'aaaaaaaaaaaaaaaaaaaaaaaa' } }
+    const { deps } = makeDeps({ findResults: [[match], [match]], hashValue: 'h1' })
+    await assert.rejects(
+      () => checkDuplicate('/tmp/a', 100, undefined, deps),
+      e => e.code === 'DUPLICATE_ASSET' && e.data.hash === 'h1' && e.data.assetId === 'aaaaaaaaaaaaaaaaaaaaaaaa'
+    )
+  })
+
+  it('returns hash when multiple assets share a size but none share the hash (size-collision regression guard)', async () => {
+    const a = { _id: 'a' }
+    const b = { _id: 'b' }
+    const { deps } = makeDeps({ findResults: [[a, b], []], hashValue: 'h1' })
+    const result = await checkDuplicate('/tmp/a', 100, undefined, deps)
+    assert.equal(result, 'h1')
+  })
+
+  it('throws DUPLICATE_ASSET when multiple share a size and one shares the hash', async () => {
+    const a = { _id: 'a' }
+    const b = { _id: { toString: () => 'b' } }
+    const { deps } = makeDeps({ findResults: [[a, b], [b]], hashValue: 'h1' })
+    await assert.rejects(
+      () => checkDuplicate('/tmp/a', 100, undefined, deps),
+      e => e.code === 'DUPLICATE_ASSET' && e.data.assetId === 'b'
+    )
+  })
+
+  it('applies excludeQuery to both size and hash lookups', async () => {
+    const { deps, calls } = makeDeps({ findResults: [[{ _id: 'x' }], []], hashValue: 'h1' })
+    await checkDuplicate('/tmp/a', 100, { _id: { $ne: 'self' } }, deps)
+    assert.deepEqual(calls.find[0], { size: 100, _id: { $ne: 'self' } })
+    assert.deepEqual(calls.find[1], { hash: 'h1', _id: { $ne: 'self' } })
+  })
+})

--- a/tests/utils-generateHash.spec.js
+++ b/tests/utils-generateHash.spec.js
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import generateHash from '../lib/utils/generateHash.js'
+
+function createTempFile (content) {
+  const filepath = path.join(os.tmpdir(), `test-hash-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  fs.writeFileSync(filepath, content)
+  return filepath
+}
+
+function expectedHash (content) {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
+
+describe('generateHash', () => {
+  it('should return a SHA-256 hex digest', async () => {
+    const filepath = createTempFile('hello world')
+    try {
+      const hash = await generateHash(filepath)
+      assert.equal(hash, expectedHash('hello world'))
+    } finally {
+      fs.unlinkSync(filepath)
+    }
+  })
+
+  it('should produce consistent hashes for identical content', async () => {
+    const content = 'duplicate content'
+    const file1 = createTempFile(content)
+    const file2 = createTempFile(content)
+    try {
+      const hash1 = await generateHash(file1)
+      const hash2 = await generateHash(file2)
+      assert.equal(hash1, hash2)
+    } finally {
+      fs.unlinkSync(file1)
+      fs.unlinkSync(file2)
+    }
+  })
+
+  it('should produce different hashes for different content', async () => {
+    const file1 = createTempFile('content A')
+    const file2 = createTempFile('content B')
+    try {
+      const hash1 = await generateHash(file1)
+      const hash2 = await generateHash(file2)
+      assert.notEqual(hash1, hash2)
+    } finally {
+      fs.unlinkSync(file1)
+      fs.unlinkSync(file2)
+    }
+  })
+
+  it('should return a 64-character hex string', async () => {
+    const filepath = createTempFile('test')
+    try {
+      const hash = await generateHash(filepath)
+      assert.equal(hash.length, 64)
+      assert.match(hash, /^[0-9a-f]{64}$/)
+    } finally {
+      fs.unlinkSync(filepath)
+    }
+  })
+
+  it('should handle empty files', async () => {
+    const filepath = createTempFile('')
+    try {
+      const hash = await generateHash(filepath)
+      assert.equal(hash, expectedHash(''))
+    } finally {
+      fs.unlinkSync(filepath)
+    }
+  })
+
+  it('should reject for non-existent files', async () => {
+    await assert.rejects(
+      () => generateHash('/tmp/non-existent-file-' + Date.now()),
+      { code: 'ENOENT' }
+    )
+  })
+})


### PR DESCRIPTION
### Fixes #61

### New
- SHA-256 content hashing on asset upload to detect and prevent duplicate files
- `DUPLICATE_ASSET` error (HTTP 409) returned when a duplicate is detected, including the existing asset's ID
- `hash` field added to asset schema (read-only, internal)
- MongoDB index on `hash` for efficient lookups
- `generateHash` utility in `lib/utils/` with full unit tests
- Migration script (`lib/migrate-hashes.js`) to backfill hashes on existing records

### Testing
- `generateHash` unit tests: consistent SHA-256 output, identical content produces same hash, different content produces different hashes, empty files, non-existent file rejection
- Run: `node --test 'tests/**/*.spec.js'`

**Note:** The `AdaptFrameworkImport` pre-check (batch hash lookup before import) is in the `adapt-authoring-adaptframework` module and will be addressed separately.