### PR TITLE
Fix: NOT_FOUND error exposes internal file path instead of asset identifier (fixes #63)

### DIFF
--- a/lib/LocalAsset.js
+++ b/lib/LocalAsset.js
@@ -57,7 +57,7 @@ class LocalAsset extends AbstractAsset {
       if (!this.path) throw App.instance.errors.ASSET_NO_PATH.setData({ title: this.data.title })
       await fsPromises.stat(this.path)
     } catch (e) {
-      if (e.code === 'ENOENT') throw App.instance.errors.NOT_FOUND.setData({ type: 'asset', id: this.path })
+      if (e.code === 'ENOENT') throw App.instance.errors.NOT_FOUND.setData({ type: 'asset', id: this.data._id?.toString() ?? this.filename })
       throw e
     }
   }


### PR DESCRIPTION
https://github.com/adapt-security/adapt-authoring-assets/issues/63

### Fix
* Use asset `_id` (or filename as fallback) instead of the internal file path in the `NOT_FOUND` error thrown by `LocalAsset#assertExists`, preventing exposure of server file paths in error responses