### PR TITLE
New: Add endpoint to count courses an asset is used in (fixes #67)

### DIFF
--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -1,11 +1,13 @@
 import AbstractApiModule from 'adapt-authoring-api'
 import AbstractAsset from './AbstractAsset.js'
+import buildAssetUsagePipeline from './utils/buildAssetUsagePipeline.js'
 import checkDuplicate from './utils/checkDuplicate.js'
 import ffmpeg from '@ffmpeg-installer/ffmpeg'
 import ffprobe from '@ffprobe-installer/ffprobe'
 import fs from 'fs/promises'
 import generateHash from './utils/generateHash.js'
 import LocalAsset from 'adapt-authoring-assets/lib/LocalAsset.js'
+import { parseObjectId } from 'adapt-authoring-mongodb'
 /**
  * Handling of assets
  * @memberof assets
@@ -148,6 +150,27 @@ class Assetsmodule extends AbstractApiModule {
       const fileStream = await (wantsThumb ? asset.thumb.read() : asset.read())
       res.set('Content-Type', `${asset.data.type}/${asset.data.subtype}`)
       fileStream.pipe(res)
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  /**
+   * Returns a map of asset _id to the number of distinct courses each asset is referenced by.
+   * Reads the content collection's indexed `_assetIds` field. Accepts an optional `assetIds` array
+   * in the request body to scope the counts to specific assets (e.g. the page of assets currently
+   * shown in the UI); assets with no usage are omitted from the response.
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {function} next
+   */
+  async usageHandler (req, res, next) {
+    try {
+      const [content, mongodb] = await this.app.waitForModule('content', 'mongodb')
+      const assetIds = Array.isArray(req.body?.assetIds) ? req.body.assetIds.map(parseObjectId) : undefined
+      const pipeline = buildAssetUsagePipeline(assetIds)
+      const results = await mongodb.getCollection(content.collectionName).aggregate(pipeline).toArray()
+      res.json(Object.fromEntries(results.map(r => [r._id.toString(), r.courseCount])))
     } catch (e) {
       next(e)
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,2 +1,3 @@
+export { default as buildAssetUsagePipeline } from './utils/buildAssetUsagePipeline.js'
 export { default as checkDuplicate } from './utils/checkDuplicate.js'
 export { default as generateHash } from './utils/generateHash.js'

--- a/lib/utils/buildAssetUsagePipeline.js
+++ b/lib/utils/buildAssetUsagePipeline.js
@@ -1,0 +1,29 @@
+/**
+ * Builds the aggregation pipeline that counts, per asset, how many distinct courses reference it.
+ *
+ * Operates on the content collection's `_assetIds` field (maintained on every content
+ * insert/update). The leading `$match` lets the query use the `_assetIds` index when scoped; the
+ * post-`$unwind` `$match` discards the other asset ids carried by matched documents so only the
+ * requested assets remain. Counting distinct `_courseId` (rather than documents) means an asset
+ * used by many content items in one course still counts as a single course.
+ *
+ * Pure helper extracted from {@link AssetsModule#usageHandler} so it can be unit-tested without
+ * booting the app. Asset ids must already be coerced to ObjectId — `getCollection().aggregate()`
+ * is the raw driver and does not normalise ObjectId strings the way the module query layer does.
+ *
+ * @param {Array} [assetIds] Asset ObjectIds to scope the counts to. Omit/empty to count all assets.
+ * @returns {Array<Object>} A MongoDB aggregation pipeline
+ * @memberof assets
+ */
+export default function buildAssetUsagePipeline (assetIds) {
+  const match = Array.isArray(assetIds) && assetIds.length > 0
+    ? { $match: { _assetIds: { $in: assetIds } } }
+    : null
+  return [
+    ...(match ? [match] : []),
+    { $unwind: '$_assetIds' },
+    ...(match ? [match] : []),
+    { $group: { _id: '$_assetIds', courses: { $addToSet: '$_courseId' } } },
+    { $project: { courseCount: { $size: '$courses' } } }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "adapt-authoring-api": "^3.0.0",
     "adapt-authoring-core": "^3.0.0",
+    "adapt-authoring-mongodb": "^3.1.0",
     "mime": "^4.1.0"
   },
   "peerDependencies": {

--- a/routes.json
+++ b/routes.json
@@ -12,6 +12,29 @@
           "responses": { "200": { "description": "The asset file" } }
         }
       }
+    },
+    {
+      "route": "/usage",
+      "handlers": { "post": "usageHandler" },
+      "permissions": { "post": ["read:${scope}"] },
+      "meta": {
+        "post": {
+          "summary": "Count how many distinct courses each asset is used in",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "assetIds": { "type": "array", "items": { "type": "string" }, "description": "Optional list of asset _ids to scope the counts to. Omit to count all assets." }
+                  }
+                }
+              }
+            }
+          },
+          "responses": { "200": { "description": "Object mapping asset _id to the number of distinct courses referencing it; assets with no usage are omitted" } }
+        }
+      }
     }
   ]
 }

--- a/tests/utils-buildAssetUsagePipeline.spec.js
+++ b/tests/utils-buildAssetUsagePipeline.spec.js
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import buildAssetUsagePipeline from '../lib/utils/buildAssetUsagePipeline.js'
+
+const GROUP = { $group: { _id: '$_assetIds', courses: { $addToSet: '$_courseId' } } }
+const PROJECT = { $project: { courseCount: { $size: '$courses' } } }
+
+describe('buildAssetUsagePipeline', () => {
+  for (const [name, input] of [
+    ['no argument', undefined],
+    ['null', null],
+    ['empty array', []]
+  ]) {
+    it(`counts all assets when given ${name} (no $match, single $unwind)`, () => {
+      const pipeline = buildAssetUsagePipeline(input)
+      assert.deepEqual(pipeline, [
+        { $unwind: '$_assetIds' },
+        GROUP,
+        PROJECT
+      ])
+      assert.equal(pipeline.filter(s => s.$match).length, 0)
+    })
+  }
+
+  it('scopes with a $match before and after $unwind when asset ids are given', () => {
+    const ids = ['id-a', 'id-b']
+    const pipeline = buildAssetUsagePipeline(ids)
+    const expectedMatch = { $match: { _assetIds: { $in: ids } } }
+    assert.deepEqual(pipeline, [
+      expectedMatch,
+      { $unwind: '$_assetIds' },
+      expectedMatch,
+      GROUP,
+      PROJECT
+    ])
+  })
+
+  it('places the pre-$unwind $match first so the _assetIds index can be used', () => {
+    const pipeline = buildAssetUsagePipeline(['id-a'])
+    assert.ok(pipeline[0].$match, 'first stage should be a $match')
+    assert.equal(pipeline[1].$unwind, '$_assetIds')
+  })
+
+  it('embeds the supplied ids verbatim (caller is responsible for ObjectId coercion)', () => {
+    const ids = [{ marker: 'objectid' }]
+    const pipeline = buildAssetUsagePipeline(ids)
+    assert.equal(pipeline[0].$match._assetIds.$in[0], ids[0])
+  })
+})


### PR DESCRIPTION
### Fixes #67

### New
* Adds `POST /api/assets/usage`, returning a map of asset `_id` → number of **distinct** courses referencing it.
* Accepts an optional `assetIds` array in the request body to scope the counts to specific assets (e.g. the page of assets shown in the UI); omit it to count all assets.
* Counts are computed in a single aggregation over the content collection's indexed `_assetIds` field; the distinct-course count is via `$addToSet` of `_courseId` so an asset used by many content items in one course still counts once.
* Extracts the pipeline construction into the pure, unit-tested `lib/utils/buildAssetUsagePipeline.js`.
* Adds `adapt-authoring-mongodb` as a dependency (the handler imports `parseObjectId`; the raw aggregate driver does not coerce ObjectId strings the way the module query layer does). The `content` module is reached via `waitForModule` at request time rather than declared as a peer dependency, to avoid a circular peer dep (content already peer-depends on assets).

### Notes / limitations
* **Local assets only** — external (URL) assets are not tracked in `_assetIds`, so they are absent from the response (callers should treat a missing key as 0). Assets with no usage are likewise omitted.
* **Not access-scoped** — the aggregation uses the raw driver and so bypasses `accessQueryHook`; counts include courses the requesting user may not be able to access. Acceptable for a usage indicator; can be tightened later if needed.

### Testing
1. `node --test tests/**/*.spec.js` — covers `buildAssetUsagePipeline` (scoped/unscoped pipeline shape, index-friendly $match ordering).
2. Manual: `POST /api/assets/usage` with no body → counts for all assets; with `{ "assetIds": ["<id>"] }` → count for those assets. Verify an asset used by multiple blocks within one course reports `1`, and an asset used across two courses reports `2`.