### PR TITLE
New: per-MIME-category asset upload size limits (+ maxFileSize key fix)

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -54,7 +54,7 @@
         "video/webm"
       ]
     },
-    "assetMaxFileSize": {
+    "maxFileSize": {
       "description": "Maximum asset file upload size",
       "type": "string",
       "isBytes": true,

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -55,12 +55,26 @@
       ]
     },
     "maxFileSize": {
-      "description": "Maximum asset file upload size",
+      "description": "Maximum asset file upload size; the fallback for any MIME category without a maxFileSizeByType entry",
       "type": "string",
       "isBytes": true,
       "isMutable": true,
       "isPublic": true,
       "default": "50mb"
+    },
+    "maxFileSizeByType": {
+      "description": "Per-MIME-category upload size limits, keyed by top-level MIME category (image, audio, video, application, font, text). Overrides maxFileSize for matching categories; other types fall back to maxFileSize.",
+      "type": "object",
+      "isMutable": true,
+      "isPublic": true,
+      "default": {
+        "image": "10mb",
+        "audio": "50mb",
+        "video": "250mb",
+        "application": "50mb",
+        "font": "2mb",
+        "text": "2mb"
+      }
     },
     "thumbnailDir": {
       "description": "Location of local thumbs dir",

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -121,6 +121,7 @@ class Assetsmodule extends AbstractApiModule {
     const middleware = await this.app.waitForModule('middleware')
     const opts = {
       maxFileSize: this.getConfig('maxFileSize'),
+      maxFileSizeByType: this.getConfig('maxFileSizeByType'),
       promisify: true
     }
     const fileTypes = this.getConfig('expectedFileTypes')


### PR DESCRIPTION
Depends on enforcement in adapt-authoring-middleware (per-MIME-category limits land there).

### Fix
- The upload handler reads `getConfig('maxFileSize')`, but the schema declared the key as `assetMaxFileSize`, so the lookup returned `undefined` and the size limit was never applied. Renamed the schema key to `maxFileSize`.

### New
- Added `maxFileSizeByType` — per-MIME-category upload limits (keys: `image`, `audio`, `video`, `application`, `font`, `text`), with `maxFileSize` as the fallback for unlisted categories. Defaults: image 10mb · audio 50mb · video 250mb · application 50mb · font 2mb · text 2mb. `onRequest` passes the map to the upload parsers.
- Course zip imports are unaffected — they use `adapt-authoring-adaptframework.importMaxFileSize` and don't pass this map.

### Testing
- Per-category enforcement is unit-tested in the middleware PR (`resolveFileSizeLimit`).