### PR TITLE
Update: make asset description optional

### DIFF
--- a/schema/asset.schema.json
+++ b/schema/asset.schema.json
@@ -100,5 +100,5 @@
       "format": "uri"
     }
   },
-  "required": ["title", "description"]
+  "required": ["title"]
 }


### PR DESCRIPTION
### Update
- Removed `description` from the asset schema's `required` list, so assets can be created/saved without a description (only `title` remains required).

### Testing
- Create or edit an asset leaving the description blank — it now validates and saves successfully.