### PR TITLE
Fix: return 400 when uploading an asset without a file

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -74,6 +74,10 @@
     "description": "Assets are missing",
     "statusCode": 500
   },
+  "MISSING_FILE": {
+    "description": "No file was provided for the asset",
+    "statusCode": 400
+  },
   "PARSE_EXT": {
     "data": {
       "file": "File name"

--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -187,6 +187,7 @@ class Assetsmodule extends AbstractApiModule {
 
   /** @override */
   async insert (data, options, mongoOptions) {
+    if (!data.file) throw this.app.errors.MISSING_FILE
     const hash = await this.checkDuplicate(data.file.filepath, data.file.size)
     const doc = await super.insert(data, options, mongoOptions)
     try {


### PR DESCRIPTION
### Fix
- `AssetsModule#insert` assumed `data.file` was always present and accessed `data.file.filepath` directly. A create request with no uploaded file (and no `url`) left `data.file` undefined, throwing an unhandled `TypeError: Cannot read properties of undefined (reading 'filepath')` and returning a 500.
- Added a guard that throws the new `MISSING_FILE` error (400) when no file is supplied, so the client gets a meaningful validation response instead of a crash.

### Testing
- POST a new asset without a file part (and without a `url`) — the request now returns 400 `MISSING_FILE` rather than a 500.