### PR TITLE
New: Content-Disposition on the asset serve route for downloads

### DIFF
--- a/lib/AssetsModule.js
+++ b/lib/AssetsModule.js
@@ -6,6 +6,7 @@ import ffprobe from '@ffprobe-installer/ffprobe'
 import fs from 'fs/promises'
 import generateHash from './utils/generateHash.js'
 import LocalAsset from 'adapt-authoring-assets/lib/LocalAsset.js'
+import path from 'path'
 /**
  * Handling of assets
  * @memberof assets
@@ -147,6 +148,11 @@ class Assetsmodule extends AbstractApiModule {
       // fall back to the main asset when a thumb is requested but none exists (e.g. SVG)
       const wantsThumb = req.query.thumb === 'true' && asset.hasThumb
       const fileStream = await (wantsThumb ? asset.thumb.read() : asset.read())
+      if (req.query.download === 'true') {
+        const ext = path.extname(asset.data.path ?? '')
+        const name = asset.data.title ?? String(asset.data._id)
+        res.attachment(ext && !name.toLowerCase().endsWith(ext.toLowerCase()) ? `${name}${ext}` : name)
+      }
       res.set('Content-Type', `${asset.data.type}/${asset.data.subtype}`)
       fileStream.pipe(res)
     } catch (e) {


### PR DESCRIPTION
### New
- The serve route now accepts `?download=true`. When set, it responds with `Content-Disposition: attachment` and a filename built from the asset title plus the original file extension (derived from the stored `path`, which is `<id>.<ext>`). Without the flag, serving is unchanged, so inline thumbnails/previews (`<img src>`) still render rather than downloading.

### Testing
- GET `/api/assets/serve/:id?download=true` → downloads as `<title>.<ext>`.
- GET `/api/assets/serve/:id` (and `?thumb=true`) → serves inline as before.