### PR TITLE
Update: Add isPlaceholder flag to asset schema

### DIFF
--- a/schema/asset.schema.json
+++ b/schema/asset.schema.json
@@ -37,6 +37,12 @@
         "showInUi": false
       }
     },
+    "isPlaceholder": {
+      "title": "Placeholder asset",
+      "description": "Marks this asset as a stand-in for external content-creation services",
+      "type": "boolean",
+      "default": false
+    },
     "path": {
       "description": "The relative path to the stored asset",
       "type": "string",


### PR DESCRIPTION
### Update
- Adds an `isPlaceholder` boolean to the asset schema (`default: false`), letting assets be marked as stand-ins for external content-creation services.
- Writable via the existing `write:assets` scope; queryable with no new code via the standard assets API, e.g. `GET /api/assets?isPlaceholder=true` (optionally `&type=image`). Consumers bucket results by `type` to pick one placeholder per asset type.
- Additive and backwards-compatible — existing assets default to `false`.

### Testing
- `GET /api/assets?isPlaceholder=true` returns only flagged assets; combining with `&type=<type>` scopes to a single asset type.
- Existing assets are unaffected (flag absent/false).